### PR TITLE
correct issue with non-US addresses

### DIFF
--- a/Nop.Plugin.Payments.SecureSubmit/SecureSubmitPaymentProcessor.cs
+++ b/Nop.Plugin.Payments.SecureSubmit/SecureSubmitPaymentProcessor.cs
@@ -98,7 +98,10 @@ namespace Nop.Plugin.Payments.SecureSubmit
             cardHolder.Address = new HpsAddress();
             cardHolder.Address.Address = customer.BillingAddress.Address1;
             cardHolder.Address.City = customer.BillingAddress.City;
-            cardHolder.Address.State = customer.BillingAddress.StateProvince.Abbreviation;
+            cardHolder.Address.State = 
+                customer.BillingAddress.StateProvince != null 
+                ? customer.BillingAddress.StateProvince.Abbreviation 
+                : null;
             cardHolder.Address.Zip = customer.BillingAddress.ZipPostalCode.Replace("-", "").Replace(" ", "");
             cardHolder.Address.Country = customer.BillingAddress.Country.ThreeLetterIsoCode;
 


### PR DESCRIPTION
state/province isn't selectable in these cases, so an explicit null check is required to prevent the NRE